### PR TITLE
utf8_decode() the data:

### DIFF
--- a/jplist-data-sources/php-mysql/server/server-json.php
+++ b/jplist-data-sources/php-mysql/server/server-json.php
@@ -60,7 +60,9 @@
 					
 					if($items){
 						foreach($items as $item){
-							
+						
+							$item	= array_map(utf8_encode, $item);
+						
 							if($counter > 0){
 								$json .= ",";
 							}


### PR DESCRIPTION
Convert all values of an array to UTF8,

These words in the database was causing json to display undefined
Wrocław, Poznań, KrakÓw, waRsaw, Gdańsk, poznań

as the array displays these values as Wroc�aw, Pozna�, Krak�w, waRsaw, Gda�sk, pozna�

The user code make MySQL databases support full Unicode, however this makes the code full tolerant if the user hasn't.

Alternatively you code checks if the value already is in UTF8, this way it will not reconvert.